### PR TITLE
Dummy as array, functions compatibility and type as array iteration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ class MongooseDummy {
 
         const typeofTemplate = typeof template;
         if (typeofTemplate === 'function') return template(mock); // @todo: this is not working properly
-        // @todo: add support for arrays
+        else if (Array.isArray(template)) return template[Math.floor(Math.random() * template.length)];
         else if (!faker || typeofTemplate !== 'string' || !mustache.test(template)) return mock(template);
 
         let [ category = '', type = '' ] = template.split('.');

--- a/test/faker.integration.test.js
+++ b/test/faker.integration.test.js
@@ -46,4 +46,24 @@ describe('Faker integration', function () {
         expect(Array.isArray(output)).to.be.equal(true);
     });
 
+    it('Iterate model with mixed dummy value, functions, strings and faker as mock function', async () => {
+        const dummy = new MongooseDummy(mongoose);
+        const model = dummy.schemas.product.schema.obj;
+
+        function containsState(value) {
+            return model.state.dummy.includes(value);
+        }
+
+        const output = await dummy.setup({ mock: faker.fake }).iterateModel(model);
+        expect(typeof output).to.be.equal('object');
+        expect('name' in output).to.be.equal(true);
+        expect('price' in output).to.be.equal(true);
+        expect('stock' in output).to.be.equal(true);
+        expect('state' in output).to.be.equal(true);
+        expect(typeof output.name).to.be.equal('string');
+        expect(typeof output.price).to.be.equal('number');
+        expect(output.stock % 3).to.be.equal(0);
+        expect(containsState(output.state)).to.be.equal(true);
+    });
+
 });

--- a/test/models/exam.js
+++ b/test/models/exam.js
@@ -1,0 +1,36 @@
+
+module.exports = function (mongoose) {
+
+    const scores = new mongoose.Schema({
+        score: {
+            type: Number,
+            dummy: '{{datatype.number}}'
+        }
+    });
+
+    const answers = new mongoose.Schema({
+        question: {
+            type: String,
+            dummy: '{{lorem.text}}?'
+        },
+        answer: {
+            type: String,
+            dummy: '{{lorem.text}}'
+        },
+        scores: {
+            type: [scores]
+        },
+    });
+
+    const schema = new mongoose.Schema({
+        name: {
+            type: String,
+            dummy: '{{lorem.words}}'
+        },
+        answers: {
+            type: [answers],
+        },
+    });
+
+    return mongoose.model('exam', schema);
+}

--- a/test/models/index.js
+++ b/test/models/index.js
@@ -1,9 +1,13 @@
 const user = require('./user');
 const organization = require('./organization');
 const commit = require('./commit');
+const exam = require('./exam');
+const product = require('./product');
 
 module.exports = function (mongoose) {
     user(mongoose);
     organization(mongoose);
     commit(mongoose);
+    exam(mongoose);
+    product(mongoose);
 }

--- a/test/models/product.js
+++ b/test/models/product.js
@@ -1,0 +1,20 @@
+
+module.exports = function (mongoose) {
+
+    const schema = new mongoose.Schema({
+        name: {
+            type: String,
+            dummy: '{{lorem.words}}'
+        },
+        price: {
+            type: String,
+            dummy: () => Math.random(),
+        },
+        stock: {
+            type: String,
+            dummy: mock => mock('{{datatype.number}}') * 3,
+        },
+    });
+
+    return mongoose.model('product', schema);
+}

--- a/test/models/product.js
+++ b/test/models/product.js
@@ -14,6 +14,10 @@ module.exports = function (mongoose) {
             type: String,
             dummy: mock => mock('{{datatype.number}}') * 3,
         },
+        state: {
+            type: String,
+            dummy: ['new', 'used', 'refused']
+        }
     });
 
     return mongoose.model('product', schema);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -87,17 +87,18 @@ describe('Test methods of MongooseDummy', function () {
 
     it('Iterate model', async () => {
         const dummy = new MongooseDummy(mongoose);
-        const model = JSON.parse(JSON.stringify(dummy.schemas.user.schema.obj));
+        const model = dummy.schemas.user.schema.obj;
         const output = await dummy.iterateModel(model);
         expect(typeof output).to.be.equal('object');
         expect('name' in output).to.be.equal(true);
+        expect('org' in output).to.be.equal(false);
         expect(typeof output.name).to.be.equal('string');
         expect(output.name).to.be.equal(model.name.dummy);
     });
 
     it('Iterate model deeper', async () => {
         const dummy = new MongooseDummy(mongoose);
-        const model = JSON.parse(JSON.stringify(dummy.schemas.organization.schema.obj));
+        const model = dummy.schemas.organization.schema.obj;
         const output = await dummy.iterateModel(model);
         expect(typeof output).to.be.equal('object');
         expect('name' in output).to.be.equal(true);
@@ -126,7 +127,7 @@ describe('Test methods of MongooseDummy', function () {
 
     it('Iterate model with fixed value', async () => {
         const dummy = new MongooseDummy(mongoose);
-        const model = JSON.parse(JSON.stringify(dummy.schemas.organization.schema.obj));
+        const model = dummy.schemas.organization.schema.obj;
         const output = await dummy.setup({ mock: () => true }).iterateModel(model);
         expect(typeof output).to.be.equal('object');
         expect('name' in output).to.be.equal(true);
@@ -156,7 +157,7 @@ describe('Test methods of MongooseDummy', function () {
     it('Iterate model with custom array length', async () => {
         const arrayLength = 20;
         const dummy = new MongooseDummy(mongoose);
-        const model = JSON.parse(JSON.stringify(dummy.schemas.organization.schema.obj));
+        const model = dummy.schemas.organization.schema.obj;
         const output = await dummy.setup({ mock: () => true, arrayLength }).iterateModel(model);
         expect(typeof output).to.be.equal('object');
         expect('users' in output).to.be.equal(true);
@@ -169,7 +170,7 @@ describe('Test methods of MongooseDummy', function () {
 
     it('Iterate model with random value from enum', async () => {
         const dummy = new MongooseDummy(mongoose);
-        const model = JSON.parse(JSON.stringify(dummy.schemas.commit.schema.obj));
+        const model = dummy.schemas.commit.schema.obj;
         const output = await dummy.setup({ mock: () => true }).iterateModel(model);
         expect(output instanceof Object).to.be.equal(true);
         expect('type' in output).to.be.equal(true);
@@ -181,6 +182,50 @@ describe('Test methods of MongooseDummy', function () {
         expect(output.message).to.be.equal(true);
         expect(typeof output.user).to.be.equal('object');
         expect(output.user.name).to.be.equal(true);
+    });
+
+    it('Iterate model with type as array', async () => {
+        const dummy = new MongooseDummy(mongoose);
+        const model = dummy.schemas.exam.schema.obj;
+        const output = await dummy.setup({ mock: () => true }).iterateModel(model);
+        expect(typeof output).to.be.equal('object');
+        expect('name' in output).to.be.equal(true);
+        expect('answers' in output).to.be.equal(true);
+        expect(Array.isArray(output.answers)).to.be.equal(true);
+        output.answers.forEach(object => {
+            expect(typeof object).to.be.equal('object');
+            expect('question' in object).to.be.equal(true);
+            expect('answer' in object).to.be.equal(true);
+            expect('scores' in object).to.be.equal(true);
+            expect(object.question).to.be.equal(true);
+            expect(object.answer).to.be.equal(true);
+            expect(Array.isArray(object.scores)).to.be.equal(true);
+            object.scores.forEach(object2 => {
+                expect(typeof object2).to.be.equal('object');
+                expect('score' in object2).to.be.equal(true);
+                expect(object2.score).to.be.equal(true);
+            });
+        });
+    });
+
+    it('Iterate model with mixed dummy value, functions and strings', async () => {
+        const dummy = new MongooseDummy(mongoose);
+        const model = dummy.schemas.product.schema.obj;
+
+        function containsState(value) {
+            return model.state.dummy.includes(value);
+        }
+
+        const output = await dummy.setup({ mock: () => 99 }).iterateModel(model);
+        expect(typeof output).to.be.equal('object');
+        expect('name' in output).to.be.equal(true);
+        expect('price' in output).to.be.equal(true);
+        expect('stock' in output).to.be.equal(true);
+        expect('state' in output).to.be.equal(true);
+        expect(output.name).to.be.equal(99);
+        expect(typeof output.price).to.be.equal('number');
+        expect(output.stock % 3).to.be.equal(0);
+        expect(containsState(output.state)).to.be.equal(true);
     });
 
     it('Iterate model through wrapper', async () => {


### PR DESCRIPTION
Now is possible to use the `dummy` key as an array, where `MongooseDummy` will select randomly from their length.

Previously the models was parsed with `JSON.parse(JSON.stringify())`, that provokes all functions were lose. So now works directly with models without parse, and is possible to set the `dummy` key as `function`, inclusive when other dummy keys are `string`, `boolean`, `object`, etc.

Finally, `MongooseDummy` will automatically try to parse on fields that have type as schema or object array. Like this:

```js
const carSchema = {
   model: {
     type: String,
    dummy: (mock) => randomModel(mock)
   },
};

const concessionaire = {
  models: {
    type: [carSchema]
  },
};
```