### PR TITLE
feat: field object value as argument in dummy as function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,12 +36,12 @@ class MongooseDummy {
         return this.schemas[modelName].schema.obj;
     }
 
-    mockProxy(template) {
+    mockProxy(template, data) {
         const { mock = value => value, faker = false } = this.config || {};
         const mustache = new RegExp(/{{\s?([^}]*)\s?}}/, 'i');
 
         const typeofTemplate = typeof template;
-        if (typeofTemplate === 'function') return template(mock); // @todo: this is not working properly
+        if (typeofTemplate === 'function') return template(mock, data);
         else if (Array.isArray(template)) return template[Math.floor(Math.random() * template.length)];
         else if (!faker || typeofTemplate !== 'string' || !mustache.test(template)) return mock(template);
 
@@ -77,7 +77,7 @@ class MongooseDummy {
 
         const getFakeValue = (object = {}) => {
             if (Array.isArray(object)) return new Array(arrayLength).fill(0).map(() => iterate(getValue(object[0]))); // If is array return 3 values and iterate
-            return 'enum' in object ? object.enum[Math.floor(Math.random() * object.enum.length)] : this.mockProxy(object.dummy);
+            return 'enum' in object ? object.enum[Math.floor(Math.random() * object.enum.length)] : this.mockProxy(object.dummy, object);
         }
 
         // Check if needs find deeper in keys

--- a/test/models/product.js
+++ b/test/models/product.js
@@ -17,7 +17,11 @@ module.exports = function (mongoose) {
         state: {
             type: String,
             dummy: ['new', 'used', 'refused']
-        }
+        },
+        variants: {
+            type: Array,
+            dummy: (_, data) => data,
+        },
     });
 
     return mongoose.model('product', schema);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -228,6 +228,21 @@ describe('Test methods of MongooseDummy', function () {
         expect(containsState(output.state)).to.be.equal(true);
     });
 
+    it('Iterate model with a fields as function return object', async () => {
+        const dummy = new MongooseDummy(mongoose);
+        const model = dummy.schemas.product.schema.obj;
+
+        const output = await dummy.setup({ mock: () => 99 }).iterateModel(model);
+        expect(typeof output).to.be.equal('object');
+        expect('variants' in output).to.be.equal(true);
+        expect(typeof output.variants).to.be.equal('object');
+        expect('type' in output.variants).to.be.equal(true);
+        expect('dummy' in output.variants).to.be.equal(true);
+        expect(typeof output.variants.type).to.be.equal('function');
+        expect(output.variants.type.name).to.be.equal('Array');
+        expect(typeof output.variants.dummy).to.be.equal('function');
+    });
+
     it('Iterate model through wrapper', async () => {
         const dummy = new MongooseDummy(mongoose);
         const output = await dummy.model('user').generate();


### PR DESCRIPTION
Now if the dummy key in fields is a function, will pass two arguments. The mock function is primary and the next one is the object value of the field.

For example:

(before)
```js
myField: {
  type: String,
  dummy: function(mockFunction) {
     // Do something with mockFunction
  }
}
```

(now)
```js
myField: {
  type: String,
  dummy: function(mockFunction, objectData) { // <--- new second argument
     // Do something with mockFunction and/or objectData
     // As base objectData will contain "type" and "dummy" key
  }
}
```

**Remember "type" is a function, so you will be able to access with `objectData.type.name`. The output is a `string` with the first letter in uppercase.