### PR TITLE
chore: remove FOSSA temp, because it's not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,3 @@ jobs:
           CC_TEST_REPORTER_ID: ${{secrets.CODECLIMATE_REPORTER_ID}}
         with:
           coverageCommand: npm run coverage:report
-
-      - name: Send to FOSSA
-        uses: fossas/fossa-action@main
-        with:
-          api-key: ${{secrets.FOSSA_API_KEY}}


### PR DESCRIPTION
Force release.

FOSSA is not working for now.