### PR TITLE
Fix compatibility with mongoose reserved keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ class MongooseDummy {
         if (!mongoose) throw new Error('Pass a valid mongoose instance.');
         this.mongooseInstance = mongoose;
         this.schemas = mongoose.models;
+        this.reserved = this.constructor.reservedKeys();
     }
 
     /**
@@ -104,6 +105,8 @@ class MongooseDummy {
 
         const { arrayLength = 3, fieldKey = 'dummy' } = this.config || {};
 
+        const isNotReserved = (key) => !this.reserved.includes(key);
+
         /**
          * Get value of schema. In case of ref the data is nested on obj key
          * @param schema {Object} - Schema or model
@@ -126,7 +129,7 @@ class MongooseDummy {
          * @param object {Object} - Model
          * @returns {false|*|boolean}
          */
-        const iterable = (object = {}) => typeof object === 'object' && !Array.isArray(object) && !(fieldKey in object) && !('enum' in object) && (populate(object) || Object.keys(object).some(key => !Array.isArray(object[key]) && typeof object[key] === 'object'));
+        const iterable = (object = {}) => typeof object === 'object' && !Array.isArray(object) && !(fieldKey in object) && !('enum' in object) && (populate(object) || Object.keys(object).some(key => isNotReserved(key) && !Array.isArray(object[key]) && typeof object[key] === 'object'));
 
         /**
          * Check if is iterable array based and apply filters
@@ -204,6 +207,10 @@ class MongooseDummy {
         }
 
         return new Promise(resolve => resolve(iterate(model)));
+    }
+
+    static reservedKeys() {
+        return ['_posts', '_pres', 'collection', 'emit', 'errors', 'get', 'init', 'isModified', 'isNew', 'listeners', 'modelName', 'on', 'once', 'populated', 'prototype', 'remove', 'removeListener', 'save', 'schema', 'toObject', 'validate']
     }
 
 }

--- a/test/models/exam.js
+++ b/test/models/exam.js
@@ -29,6 +29,12 @@ module.exports = function (mongoose) {
         },
         answers: {
             type: [answers],
+            required: true,
+            index: true,
+            validate: {
+                validator: value => Array.isArray(value),
+                message: () => 'Testing value :)',
+            },
         },
     });
 


### PR DESCRIPTION
Previously, was not possible to use reserved keys on the schema fields. That is because detecting an object trying to seed with random values.

So now exist a verification if the key is not reserved by mongoose functionality.
https://github.com/videsk/mongoose-dummy/blob/6e6b8eec0b4796efeb9b6770cd56dddb9daa2b4e/src/index.js#L132

List of reserved keys:
https://github.com/videsk/mongoose-dummy/blob/6e6b8eec0b4796efeb9b6770cd56dddb9daa2b4e/src/index.js#L213
