### PR TITLE
fix: add extra compatibility with versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import { v4 as uuid } from 'uuid';
-const { Schema, Types } = mongoose;
+const { Schema, Types, SchemaType } = mongoose;
 
 class MongooseDummy {
 
@@ -93,9 +93,9 @@ class MongooseDummy {
                 return this.constructor.getFallbackValue(schema);
             }
         }
-        else if (schema instanceof Types.Subdocument) return this.iterate(schema.schema, {}, iteration);
         else if (schema instanceof Schema.Types.ObjectId) return this.evaluateObjectId(schema, filter);
         else if (schema instanceof Schema.Types.DocumentArray || schema instanceof Schema.Types.Array) return [...Array(length)].map(() => this.getArrayItem(schema, output, filter));
+        else if (schema instanceof Types.Subdocument || (schema instanceof SchemaType && schema.schema?.paths)) return this.iterate(schema.schema, {}, iteration);
         return this.constructor.getFallbackValue(schema);
     }
 
@@ -114,7 +114,7 @@ class MongooseDummy {
     }
 
     static getFallbackValue(schema) {
-        const { Mixed, ObjectId, Number, Boolean, String, Map, Buffer, DocumentArray, BigInt, Decimal128 } = Schema.Types;
+        const { Mixed, ObjectId, Number, Boolean, String, Map, Buffer, BigInt = Number, DocumentArray, Decimal128 } = Schema.Types;
         const { max, min, default: defaultValue } = schema.options;
         if (typeof defaultValue !== 'undefined') return defaultValue;
         if (schema instanceof Schema.Types.Array || schema instanceof DocumentArray) return new Types.Array();

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ class MongooseDummy {
 
     evaluateDummy(schema, iteration = 0, output = {}, filter = () => true) {
         const { arrayLength = 3, dummyKey = 'dummy' } = this.config || {};
+        const { instance } = schema;
         if (iteration > 2) return this.constructor.getFallbackValue(schema);
         const { length = arrayLength } = schema.options[dummyKey] || {};
 
@@ -93,9 +94,9 @@ class MongooseDummy {
                 return this.constructor.getFallbackValue(schema);
             }
         }
-        else if (schema instanceof Schema.Types.ObjectId) return this.evaluateObjectId(schema, filter);
-        else if (schema instanceof Schema.Types.DocumentArray || schema instanceof Schema.Types.Array) return [...Array(length)].map(() => this.getArrayItem(schema, output, filter));
-        else if (schema instanceof Types.Subdocument || (schema instanceof SchemaType && schema.schema?.paths)) return this.iterate(schema.schema, {}, iteration);
+        else if (schema instanceof Schema.Types.ObjectId || instance === 'ObjectId') return this.evaluateObjectId(schema, filter);
+        else if (schema instanceof Schema.Types.DocumentArray || schema instanceof Schema.Types.Array || instance === 'Array') return [...Array(length)].map(() => this.getArrayItem(schema, output, filter));
+        else if (schema instanceof Types.Subdocument || schema.schema?.paths || instance === 'Embedded') return this.iterate(schema.schema, {}, iteration);
         return this.constructor.getFallbackValue(schema);
     }
 
@@ -116,14 +117,15 @@ class MongooseDummy {
     static getFallbackValue(schema) {
         const { Mixed, ObjectId, Number, Boolean, String, Map, Buffer, BigInt = Number, DocumentArray, Decimal128 } = Schema.Types;
         const { max, min, default: defaultValue } = schema.options;
+        const { instance } = schema;
         if (typeof defaultValue !== 'undefined') return defaultValue;
-        if (schema instanceof Schema.Types.Array || schema instanceof DocumentArray) return new Types.Array();
-        else if (schema instanceof Types.Subdocument || schema instanceof Mixed || schema instanceof Map) return {};
-        else if (schema instanceof ObjectId) return new Types.ObjectId();
-        else if (schema instanceof Number || schema instanceof BigInt || schema instanceof Decimal128) return this.randomNumber(min, max);
-        else if (schema instanceof Boolean) return Math.random() < 0.5;
-        else if (schema instanceof String || schema instanceof Buffer) return this.generateStringBasedOnSchemaOptions(schema.options);
-        else if (schema instanceof Schema.Types.Date) return new Date();
+        if (schema instanceof Schema.Types.Array || schema instanceof DocumentArray || instance === 'Array') return new Types.Array();
+        else if (schema instanceof Types.Subdocument || schema instanceof Mixed || schema instanceof Map || instance === 'Embedded') return {};
+        else if (schema instanceof ObjectId || instance === 'ObjectId') return new Types.ObjectId();
+        else if (schema instanceof Number || schema instanceof BigInt || schema instanceof Decimal128 || instance === 'Number') return this.randomNumber(min, max);
+        else if (schema instanceof Boolean || instance === 'Boolean') return Math.random() < 0.5;
+        else if (schema instanceof String || schema instanceof Buffer || instance === 'String') return this.generateStringBasedOnSchemaOptions(schema.options);
+        else if (schema instanceof Schema.Types.Date || instance === 'Date') return new Date();
         else if (schema instanceof (Schema.Types.UUID || String)) return uuid();
         return null;
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -74,6 +74,9 @@ describe('Test methods of MongooseDummy', function () {
         expect('name' in output).to.be.equal(true);
         expect('org' in output).to.be.equal(true);
         expect(typeof output.name).to.be.equal('string');
+        expect(typeof output.credentials).to.be.equal('object');
+        expect(output.credentials).to.have.property('subCredentials')
+        expect(output.credentials).to.have.property('secretName')
     });
 
     it('Iterate model deeper', async () => {


### PR DESCRIPTION
I noticed that tests were passing but the output wasn't as expected, so I added more tests to correctly check deeper schemas (with version 5 and 8) and made the generation compatible with both

Some types don't exist in older versions, and some schemaTypes are removed in newer versions