### PR TITLE
fix: generators usage for deep references and object works correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org
@@ -29,9 +29,9 @@ jobs:
     needs: [test]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies

--- a/src/index.js
+++ b/src/index.js
@@ -71,11 +71,11 @@ class MongooseDummy {
     iterate(schema, output = {}, iteration = 0, filter = () => true) {
         const { paths } = schema;
         for (const schemaType of Object.values(paths)) {
-            if (this.constructor.canParse(schemaType, this.config.dummyKey) && this.constructor.query(schemaType, filter)) {
-                schemaType
-                  .path
-                  .split('.')
-                  .reduce((accumulator, key, index, array) => accumulator[key] = accumulator[key] || (index === array.length - 1 ? this.evaluateDummy(schemaType, iteration, output, filter) : {}), output);
+            if (MongooseDummy.canParse(schemaType, this.config.dummyKey) && MongooseDummy.query(schemaType, filter)) {
+                const pathParts = schemaType.path.split('.');
+                const finalKey = pathParts.pop();
+                const current = pathParts.reduce((accumulator, key) => accumulator[key] = accumulator[key] || {}, output);
+                current[finalKey] = this.evaluateDummy(schemaType, iteration, output, filter);
             }
         }
         return output;
@@ -84,33 +84,33 @@ class MongooseDummy {
     evaluateDummy(schema, iteration = 0, output = {}, filter = () => true) {
         const { arrayLength = 3, dummyKey = 'dummy' } = this.config || {};
         const { instance } = schema;
-        if (iteration >= 2) return this.constructor.getFallbackValue(schema);
+        if (iteration > 2) return MongooseDummy.getFallbackValue(schema);
         const { length = arrayLength } = schema.options[dummyKey] || {};
 
         if (schema.options[dummyKey] instanceof Function) {
             try {
                 return schema.options[dummyKey].call(output, this.generators);
             } catch (error) {
-                return this.constructor.getFallbackValue(schema);
+                return MongooseDummy.getFallbackValue(schema);
             }
         }
-        else if (schema instanceof Schema.Types.ObjectId || instance === 'ObjectId') return this.evaluateObjectId(schema, filter);
-        else if (schema instanceof Schema.Types.DocumentArray || schema instanceof Schema.Types.Array || instance === 'Array') return [...Array(length)].map(() => this.getArrayItem(schema, output, filter));
+        else if (schema instanceof Schema.Types.ObjectId || instance === 'ObjectId') return this.evaluateObjectId(schema, iteration, filter);
+        else if (schema instanceof Schema.Types.DocumentArray || schema instanceof Schema.Types.Array || instance === 'Array') return [...Array(length)].map(() => this.getArrayItem(schema, output, iteration, filter));
         else if (schema instanceof Types.Subdocument || schema.schema?.paths || instance === 'Embedded') return this.iterate(schema.schema, {}, iteration);
-        return this.constructor.getFallbackValue(schema);
+        return MongooseDummy.getFallbackValue(schema);
     }
 
-    getArrayItem(schema, output, filter = () => true) {
-        if (schema?.schema instanceof Schema) return this.iterate(schema.schema, {}, 2);
+    getArrayItem(schema, output, iteration = 0, filter = () => true) {
+        if (schema?.schema instanceof Schema) return this.iterate(schema.schema, {}, iteration + 1, filter);
         const itemSchema = schema.caster;
-        if (itemSchema instanceof Schema.Types.ObjectId) return this.evaluateObjectId(itemSchema, filter);
-        return this.evaluateDummy(itemSchema, 2, output, filter);
+        if (itemSchema instanceof Schema.Types.ObjectId) return this.evaluateObjectId(itemSchema, iteration, filter);
+        return this.evaluateDummy(itemSchema, iteration + 1, output, filter);
     }
 
-    evaluateObjectId(schema, filter = () => true) {
+    evaluateObjectId(schema, iteration = 0, filter = () => true) {
         const { ref, populate } = schema.options;
-        if (ref && populate) return this.iterate(this.getModel(ref), {}, 2, filter);
-        else if (this.constructor.canParse(schema)) return new Types.ObjectId();
+        if (ref && populate) return this.iterate(this.getModel(ref), {}, iteration + 1, filter);
+        else if (MongooseDummy.canParse(schema)) return new Types.ObjectId();
         return undefined;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class MongooseDummy {
         if (schema.options[dummyKey] instanceof Function) {
             try {
                 return schema.options[dummyKey].call(output, this.generators);
-            } catch (error) {
+            } catch {
                 return MongooseDummy.getFallbackValue(schema);
             }
         }

--- a/test/faker.test.js
+++ b/test/faker.test.js
@@ -1,0 +1,27 @@
+import { mongoose, expect, faker } from './utils/index.js';
+import MongooseDummy from '../src/index.js';
+
+describe('Test generators', function () {
+
+    it('Get values from generators', () => {
+        const dummy = new MongooseDummy(mongoose);
+        dummy.generators = { faker };
+        const model = dummy.getModel('organization');
+        const output = dummy.iterate(model);
+
+        expect(typeof output).to.be.equal('object');
+        const { name, address, timezone, users, servers } = output;
+        expect(typeof name).to.be.equal('string');
+        expect(typeof address).to.be.equal('object');
+        expect(typeof address.city).to.be.equal('string');
+        expect(typeof address.country).to.be.equal('string');
+        expect(typeof timezone).to.be.equal('string');
+        expect(typeof users).to.be.equal('object');
+        expect(typeof servers).to.be.equal('object');
+        servers.forEach(server => {
+            expect(URL.canParse(server.url)).to.be.equal(true);
+            expect(server.database.includes('_')).to.be.equal(true);
+        })
+    });
+
+});

--- a/test/models/organization.js
+++ b/test/models/organization.js
@@ -3,7 +3,7 @@ export default function (mongoose) {
     const schema = new mongoose.Schema({
         name: {
             type: String,
-            dummy:  ({ faker }) => faker.company.name(),
+            dummy: ({ faker }) => faker.company.name(),
         },
         address: {
             city: {


### PR DESCRIPTION
This pull request includes several changes to the `MongooseDummy` class in `src/index.js` and adds new tests in `test/faker.test.js`. The changes focus on improving the code structure and adding tests to ensure the functionality of the dummy data generator.

Improvements to `MongooseDummy` class:

* Replaced `this.constructor` with `MongooseDummy` for method calls to improve readability and consistency. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L74-R78) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L87-R113)
* Refactored the `iterate` method to simplify the path splitting and assignment logic.
* Modified the `evaluateDummy` method to correctly handle the iteration limit and added iteration parameter to `evaluateObjectId` and `getArrayItem` methods.
* Added iteration parameter to `getArrayItem` and `evaluateObjectId` methods to ensure proper handling of nested schemas.

Addition of new tests:

* Added a new test suite in `test/faker.test.js` to verify the functionality of the dummy data generators, including checks for the structure and types of generated data.