### PR TITLE
feat: add defaultFilter to config and update generate method to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ const taskSchema = new mongoose.Schema({
 Generate data only for specific fields:
 
 ```javascript
+// Replace default filter
+dummy.defaultFilter = options => options.customKey;
+
 // Only generate required fields
 const requiredOnly = dummy.model('User').generate(
   options => options.required === true

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ class MongooseDummy {
         if (!mongoose) throw new Error('Pass a valid mongoose instance.');
         this.mongooseInstance = mongoose;
         this.schemas = mongoose.models;
-        this.config = { generators: {}, maxPopulateDepth: 1 };
+        this.config = { generators: {}, maxPopulateDepth: 1, defaultFilter: () => true };
     }
 
     /**
@@ -42,8 +42,8 @@ class MongooseDummy {
      * @param filter {Function} - Filter keys by queries
      * @returns {Promise<unknown>}
      */
-    generate(filter = () => true) {
-        return this.iterate(this.baseModel, {}, 0, filter);
+    generate(filter) {
+        return this.iterate(this.baseModel, {}, 0, filter || this.config.defaultFilter);
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -21,18 +21,50 @@ class MongooseDummy {
         return this;
     }
 
+    /**
+     * Set max populate depth
+     * @param value
+     */
     set maxPopulateDepth(value) {
         this.config.maxPopulateDepth = value;
     }
 
+    /**
+     * Get max populate depth
+     * @returns {number}
+     */
     get maxPopulateDepth() {
         return this.config.maxPopulateDepth;
     }
 
+    /**
+     * Set default filter
+     * @param value
+     */
+    set defaultFilter(value) {
+        this.config.defaultFilter = value;
+    }
+
+    /**
+     * Get default filter
+     * @returns {function(): boolean}
+     */
+    get defaultFilter() {
+        return this.config.defaultFilter;
+    }
+
+    /**
+     * Set dummy key
+     * @param generators
+     */
     set generators(generators) {
         this.config.generators = Object.assign(this.config.generators, generators);
     }
 
+    /**
+     * Get dummy key
+     * @returns {{}}
+     */
     get generators() {
         return this.config.generators;
     }


### PR DESCRIPTION
This pull request introduces a small enhancement to the `MongooseDummy` class in `src/index.js` to improve the handling of default filters when generating data.

Configuration improvements:

* Added a `defaultFilter` function to the `config` object, ensuring that a default filter is always available for data generation.

Method behavior update:

* Updated the `generate` method to use the provided filter if available, or fallback to the new `defaultFilter` from the configuration, improving robustness when no filter is specified.